### PR TITLE
Bugfix/5/list items not attaching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'slim'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'minitest-rails'
+  gem 'minitest-rails-capybara'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     bcrypt (3.1.12)
     bindex (0.5.0)
@@ -49,6 +51,13 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    capybara (2.18.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (>= 2.0, < 4.0)
     concurrent-ruby (1.1.3)
     crass (1.0.4)
     devise (4.5.0)
@@ -82,9 +91,20 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    minitest-capybara (0.9.0)
+      capybara
+      minitest (~> 5.0)
+      rake
+    minitest-metadata (0.6.0)
+      minitest (>= 4.7, < 6.0)
     minitest-rails (3.0.0)
       minitest (~> 5.8)
       railties (~> 5.0)
+    minitest-rails-capybara (3.0.1)
+      capybara (~> 2.7)
+      minitest-capybara (~> 0.8)
+      minitest-metadata (~> 0.6)
+      minitest-rails (~> 3.0)
     msgpack (1.2.4)
     multi_json (1.13.1)
     nio4r (2.3.1)
@@ -92,6 +112,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     pg (1.1.3)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -170,6 +191,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -181,6 +204,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   minitest-rails
+  minitest-rails-capybara
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.1)
@@ -195,4 +219,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+// ...
+//= require rails-ujs
+//= require_tree .

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,5 +1,6 @@
 class ListItemsController < ApplicationController
   before_action :set_list_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_list, only: [:new, :create]
 
   # GET /list_items
   # GET /list_items.json
@@ -14,7 +15,6 @@ class ListItemsController < ApplicationController
 
   # GET /list_items/new
   def new
-    @list = List.find(params[:list_id])
     @list_item = ListItem.new
   end
 
@@ -25,7 +25,6 @@ class ListItemsController < ApplicationController
   # POST /list_items
   # POST /list_items.json
   def create
-    @list = List.find(params[:list_id])
     @list_item = @list.list_items.create(list_item_params)
 
     respond_to do |format|
@@ -44,7 +43,7 @@ class ListItemsController < ApplicationController
   def update
     respond_to do |format|
       if @list_item.update(list_item_params)
-        format.html { redirect_to @list_item, notice: 'List item was successfully updated.' }
+        format.html { redirect_to @list_item.list, notice: 'List item was successfully updated.' }
         format.json { render :show, status: :ok, location: @list_item }
       else
         format.html { render :edit }
@@ -58,15 +57,20 @@ class ListItemsController < ApplicationController
   def destroy
     @list_item.destroy
     respond_to do |format|
-      format.html { redirect_to list_items_url, notice: 'List item was successfully destroyed.' }
+      format.html { redirect_to list_url(@list_item.list), notice: 'List item was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
+
     # Use callbacks to share common setup or constraints between actions.
     def set_list_item
       @list_item = ListItem.find(params[:id])
+    end
+
+    def set_list
+      @list = List.find(params[:list_id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -14,6 +14,7 @@ class ListItemsController < ApplicationController
 
   # GET /list_items/new
   def new
+    @list = List.find(params[:list_id])
     @list_item = ListItem.new
   end
 
@@ -24,11 +25,12 @@ class ListItemsController < ApplicationController
   # POST /list_items
   # POST /list_items.json
   def create
-    @list_item = ListItem.new(list_item_params)
+    @list = List.find(params[:list_id])
+    @list_item = @list.list_items.create(list_item_params)
 
     respond_to do |format|
       if @list_item.save
-        format.html { redirect_to @list_item, notice: 'List item was successfully created.' }
+        format.html { redirect_to @list, notice: 'List item was successfully created.' }
         format.json { render :show, status: :created, location: @list_item }
       else
         format.html { render :new }
@@ -69,6 +71,6 @@ class ListItemsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def list_item_params
-      params.fetch(:list_item, {})
+      params.require(:list_item).permit(:description)
     end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -44,7 +44,7 @@ class ListsController < ApplicationController
   def destroy
     @list.destroy
     respond_to do |format|
-      format.html { redirect_to lists_url, notice: 'List was successfully destroyed.' }
+      format.html { redirect_to lists_url, notice: "#{@list.title} was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,3 +1,3 @@
 class List < ApplicationRecord
-  has_many :lists
+  has_many :list_items, dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
     <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
     <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <%= javascript_include_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/list_items/_form.html.erb
+++ b/app/views/list_items/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: list_item, local: true) do |form| %>
+<%= form_with(model: [@list, list_item], local: true) do |form| %>
   <% if list_item.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(list_item.errors.count, "error") %> prohibited this list_item from being saved:</h2>
@@ -11,8 +11,8 @@
     </div>
   <% end %>
 
-  <%= form.label, :description %>
-  <%= form.text_feild, :description %>
+  <%= form.label :description %>
+  <%= form.text_field :description %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/list_items/edit.html.erb
+++ b/app/views/list_items/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', list_item: @list_item %>
 
 <%= link_to 'Show', @list_item %> |
-<%= link_to 'Back', list_items_path %>
+<%= link_to 'Back', list_path(@list_item.list) %>

--- a/app/views/list_items/new.html.erb
+++ b/app/views/list_items/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', list_item: @list_item %>
 
-<%= link_to 'Back', list_items_path %>
+<%= link_to 'Back', list_path(@list) %>

--- a/app/views/list_items/show.html.erb
+++ b/app/views/list_items/show.html.erb
@@ -1,4 +1,6 @@
 <p id="notice"><%= notice %></p>
 
+<h1><%= @list_item.description %></h1>
+
 <%= link_to 'Edit', edit_list_item_path(@list_item) %> |
-<%= link_to 'Back', list_items_path %>
+<%= link_to 'Back', list_path(@list_item.list) %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -5,13 +5,14 @@
 <table>
   <thead>
     <tr>
-      <th colspan="3"></th>
+      <th colspan="4"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @lists.each do |list| %>
       <tr>
+        <td><%= list.title %></td>
         <td><%= link_to 'Show', list %></td>
         <td><%= link_to 'Edit', edit_list_path(list) %></td>
         <td><%= link_to 'Destroy', list, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,4 +1,28 @@
 <p id="notice"><%= notice %></p>
 
+<h1><%= @list.title %></h1>
+
+<table class="list-items">
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @list.list_items.each do |item| %>
+      <tr>
+        <td><%= item.description %></td>
+        <td><%= link_to 'Edit', edit_list_item_path(item) %></td>
+        <td><%= link_to 'Destroy', item, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to 'New Item', new_list_list_item_path(list_id: @list.id) %>
+
+<br>
+
 <%= link_to 'Edit', edit_list_path(@list) %> |
 <%= link_to 'Back', lists_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  resources :list_items
-  resources :lists
-  devise_for :users
   root to: 'static#index'
+  resources :lists do
+    resources :list_items, shallow: true
+  end
+  devise_for :users
 end

--- a/test/features/user_adds_item_to_list_test.rb
+++ b/test/features/user_adds_item_to_list_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+feature "UserAddsItemToList" do
+  scenario "successfully" do
+    create_new_list('New List')
+    add_item_to_list('New Item')
+
+    expect(page).must_have_css '.list-items td', text: 'New Item'
+  end
+end

--- a/test/features/user_adds_item_to_list_test.rb
+++ b/test/features/user_adds_item_to_list_test.rb
@@ -1,7 +1,7 @@
-require "test_helper"
+require 'test_helper'
 
-feature "UserAddsItemToList" do
-  scenario "successfully" do
+feature 'UserAddsItemToList' do
+  scenario 'successfully' do
     create_new_list('New List')
     add_item_to_list('New Item')
 

--- a/test/features/user_creates_new_list_test.rb
+++ b/test/features/user_creates_new_list_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+feature 'UserCreatesNewList' do
+  scenario 'successfully' do
+    create_new_list('Test Todo List')
+
+    expect(page).must_have_css 'h1', text: 'Test Todo List'
+  end
+end

--- a/test/features/user_deletes_list_item_test.rb
+++ b/test/features/user_deletes_list_item_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+feature "UserDeletesListItem" do
+  scenario "successfully" do
+    create_new_list('Throwaway List')
+    add_item_to_list('Delete this item')
+
+    click_on 'Destroy'
+
+    expect(page).must_have_css 'h1', text: 'Throwaway List'
+    expect(page).wont_have_css '.list-items td', text: 'Delete this item'
+  end
+end

--- a/test/features/user_deletes_list_test.rb
+++ b/test/features/user_deletes_list_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+feature 'UserDeletesList' do
+  scenario 'successfully' do
+    create_new_list('Throwaway List')
+
+    visit lists_path
+    click_on 'Destroy'
+
+    expect(page).must_have_css 'h1', text: 'Lists'
+    expect(page).wont_have_css 'td', text: 'Throwaway List'
+  end
+end

--- a/test/features/user_edits_list_item_test.rb
+++ b/test/features/user_edits_list_item_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+feature 'UserEditsListItem' do
+  scenario 'successfully' do
+    create_new_list('ToDo')
+    add_item_to_list('Throwaway item')
+
+    update_list_item_description('Updated item')
+
+    expect(page).wont_have_css '.list-items td', text: 'Throwaway item'
+    expect(page).must_have_css '.list-items td', text: 'Updated item'
+  end
+end

--- a/test/features/user_edits_list_test.rb
+++ b/test/features/user_edits_list_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+feature 'UserEditsList' do
+  scenario 'successfully' do
+    create_new_list('Throwaway List')
+
+    update_list_title('Keeper List')
+
+    expect(page).must_have_css 'h1', text: 'Keeper List'
+  end
+end

--- a/test/features/user_visits_homepage_test.rb
+++ b/test/features/user_visits_homepage_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+# smoke test
+feature 'User visits homepage' do
+  scenario 'successfully' do
+    visit root_path
+
+    page.must_have_css 'h1', text: 'Listr'
+  end
+end

--- a/test/support/feature_helper.rb
+++ b/test/support/feature_helper.rb
@@ -1,0 +1,28 @@
+module FeatureHelper
+  def create_new_list(title)
+    visit lists_path
+    click_on 'New List'
+    fill_in 'Title', with: title
+    click_on 'Create List'
+  end
+
+  def add_item_to_list(desc)
+    click_on 'New Item'
+    fill_in 'Description', with: desc
+    click_on 'Create List item'
+  end
+
+  def update_list_item_description(desc)
+    within('.list-items') do
+      click_on 'Edit'
+    end
+    fill_in 'Description', with: desc
+    click_on 'Update List item'
+  end
+
+  def update_list_title(title)
+    click_on 'Edit'
+    fill_in 'Title', with: title
+    click_on 'Update List'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require "minitest/rails"
 
 # To add Capybara feature tests add `gem "minitest-rails-capybara"`
 # to the test group in the Gemfile and uncomment the following:
-# require "minitest/rails/capybara"
+require "minitest/rails/capybara"
 
 # Uncomment for awesome colorful output
 # require "minitest/pride"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,4 +26,18 @@ class ActiveSupport::TestCase
     fill_in 'Description', with: desc
     click_on 'Create List item'
   end
+
+  def update_list_item_description(desc)
+    within('.list-items') do
+      click_on 'Edit'
+    end
+    fill_in 'Description', with: desc
+    click_on 'Update List item'
+  end
+
+  def update_list_title(title)
+    click_on 'Edit'
+    fill_in 'Title', with: title
+    click_on 'Update List'
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,4 +14,16 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
   # Add more helper methods to be used by all tests here...
+  def create_new_list(title)
+    visit lists_path
+    click_on 'New List'
+    fill_in 'Title', with: title
+    click_on 'Create List'
+  end
+
+  def add_item_to_list(desc)
+    click_on 'New Item'
+    fill_in 'Description', with: desc
+    click_on 'Create List item'
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,8 @@ require "minitest/rails"
 # to the test group in the Gemfile and uncomment the following:
 require "minitest/rails/capybara"
 
+require_relative "./support/feature_helper"
+
 # Uncomment for awesome colorful output
 # require "minitest/pride"
 
@@ -14,30 +16,5 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
   # Add more helper methods to be used by all tests here...
-  def create_new_list(title)
-    visit lists_path
-    click_on 'New List'
-    fill_in 'Title', with: title
-    click_on 'Create List'
-  end
-
-  def add_item_to_list(desc)
-    click_on 'New Item'
-    fill_in 'Description', with: desc
-    click_on 'Create List item'
-  end
-
-  def update_list_item_description(desc)
-    within('.list-items') do
-      click_on 'Edit'
-    end
-    fill_in 'Description', with: desc
-    click_on 'Update List item'
-  end
-
-  def update_list_title(title)
-    click_on 'Edit'
-    fill_in 'Title', with: title
-    click_on 'Update List'
-  end
+  include FeatureHelper
 end


### PR DESCRIPTION
This branch fixes bugs related to list items not properly attaching to lists and adds a regression suite (using Capybara) to verify that basic crud operations for lists & list_items work. I decided to nest the routes for list_items since they always belong to a list and I needed the list_id to associate them properly. I also included rails-ujs so that the delete links would function.