### PR TITLE
Style/3/new color options

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,10 +1,14 @@
+// COLORS
+$carrot-orange: hsl(29, 90%, 50%);
+$corvette: hsl(27, 72%, 70%);
+
 .heading {
   height: 50vh;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: #BAD;
+  background-color: $corvette;
   color: #FFF;
 
   H1 {
@@ -14,4 +18,13 @@
   p {
     font-size: 1.5em;
   }
+}
+
+a {
+  color: $carrot-orange;
+}
+
+.button, button, input[type='button'], input[type='reset'], input[type='submit'] {
+  background-color: $carrot-orange;
+  border-color: $carrot-orange;
 }

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,6 +1,32 @@
 // COLORS
-$islamic-green: hsl(123, 95%, 36%);
-$pastel-green: hsl(125, 55%, 68%);
+$burnt-yellow: hsl(54, 90%, 48%);
+$background-light: hsl(0, 0%, 20%);
+$dark-text: hsl(0, 0%, 16%);
+$red-text: hsl(5, 80%, 40%);
+$teal-text: hsl(170, 40%, 55%);
+$purple-text: hsl(278, 60%, 66%);
+$light-gray: hsl(0, 0%, 85%);
+
+body {
+  background-color: $dark-text;
+  color: $light-gray;
+}
+
+h1 {
+  color: $red-text;
+}
+
+label {
+  color: $purple-text;
+}
+
+p {
+  color: $teal-text;
+}
+
+a {
+  color: $burnt-yellow;
+}
 
 .heading {
   height: 50vh;
@@ -8,23 +34,26 @@ $pastel-green: hsl(125, 55%, 68%);
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: $pastel-green;
+  background-color: $background-light;
   color: #FFF;
 
   H1 {
     font-size: 5em;
+    // color: $red-text;
   }
-   
+
   p {
     font-size: 1.5em;
+    // color: $teal-text;
   }
-}
-
-a {
-  color: $islamic-green;
 }
 
 .button, button, input[type='button'], input[type='reset'], input[type='submit'] {
-  background-color: $islamic-green;
-  border-color: $islamic-green;
+  background-color: $burnt-yellow;
+  border-color: $burnt-yellow;
+  color: $dark-text;
+}
+
+input {
+  color: $teal-text;
 }

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,6 +1,6 @@
 // COLORS
-$carrot-orange: hsl(29, 90%, 50%);
-$corvette: hsl(27, 72%, 70%);
+$islamic-green: hsl(123, 95%, 36%);
+$pastel-green: hsl(125, 55%, 68%);
 
 .heading {
   height: 50vh;
@@ -8,7 +8,7 @@ $corvette: hsl(27, 72%, 70%);
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: $corvette;
+  background-color: $pastel-green;
   color: #FFF;
 
   H1 {
@@ -21,10 +21,10 @@ $corvette: hsl(27, 72%, 70%);
 }
 
 a {
-  color: $carrot-orange;
+  color: $islamic-green;
 }
 
 .button, button, input[type='button'], input[type='reset'], input[type='submit'] {
-  background-color: $carrot-orange;
-  border-color: $carrot-orange;
+  background-color: $islamic-green;
+  border-color: $islamic-green;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all' %>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
     <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
     <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <%= stylesheet_link_tag    'application', media: 'all' %>
   </head>
 
   <body>


### PR DESCRIPTION
I've created 3 different options for new color schemes. Each is in a different commit on this branch. Screenshots below.

## Orange
<img width="826" alt="orange-home" src="https://user-images.githubusercontent.com/15739331/49764205-06880a80-fc8c-11e8-8309-ce89f826aadf.png">
<img width="267" alt="orange-form" src="https://user-images.githubusercontent.com/15739331/49764215-0a1b9180-fc8c-11e8-8ba5-934b2b14b10c.png">

---

## Green
<img width="813" alt="green-home" src="https://user-images.githubusercontent.com/15739331/49764223-0f78dc00-fc8c-11e8-93f6-40997eeb2d17.png">
<img width="266" alt="green-form" src="https://user-images.githubusercontent.com/15739331/49764229-1273cc80-fc8c-11e8-8858-eb587c4076b4.png">

---

## Dark
<img width="827" alt="dark-home" src="https://user-images.githubusercontent.com/15739331/49764234-169fea00-fc8c-11e8-8837-274ba271c573.png">
<img width="264" alt="dark-form" src="https://user-images.githubusercontent.com/15739331/49764237-19024400-fc8c-11e8-9d6a-45c80dde432b.png">
