### PR TITLE
Feature/4/add categories to lists

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -10,8 +10,12 @@
   H1 {
     font-size: 5em;
   }
-   
+
   p {
     font-size: 1.5em;
   }
+}
+
+.column {
+  text-align: center;
 }

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,8 +1,9 @@
 class ListsController < ApplicationController
   before_action :set_list, only: [:show, :edit, :update, :destroy]
+  before_action :set_type, only: [:index, :create]
 
   def index
-    @lists = List.all
+    @lists = @type.all
   end
 
   def show
@@ -16,7 +17,7 @@ class ListsController < ApplicationController
   end
 
   def create
-    @list = List.new(list_params)
+    @list = @type.new(list_params)
 
     respond_to do |format|
       if @list.save
@@ -54,7 +55,11 @@ class ListsController < ApplicationController
       @list = List.find(params[:id])
     end
 
+    def set_type
+      @type = params[:type] ? params[:type].constantize : List
+    end
+
     def list_params
-      params.require(:list).permit(:title, :description)
+      params.require(:list).permit(:title, :description, :type)
     end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -1,0 +1,5 @@
+module LayoutHelper
+  def list_types
+    List.select_options
+  end
+end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -1,5 +1,0 @@
-module LayoutHelper
-  def list_types
-    List.select_options
-  end
-end

--- a/app/helpers/list_helper.rb
+++ b/app/helpers/list_helper.rb
@@ -1,0 +1,6 @@
+module ListHelper
+  def list_display_heading
+    heading = @type.to_s == 'List' ? 'All' : @type.to_s
+    heading += ' Lists'
+  end
+end

--- a/app/helpers/list_helper.rb
+++ b/app/helpers/list_helper.rb
@@ -3,4 +3,8 @@ module ListHelper
     heading = @type.to_s == 'List' ? 'All' : @type.to_s
     heading += ' Lists'
   end
+
+  def list_types
+    List.select_options
+  end
 end

--- a/app/models/basic.rb
+++ b/app/models/basic.rb
@@ -1,0 +1,7 @@
+class Basic < List
+  validates :title, presence: true
+  # enables use of existing route and form helpers
+  def self.model_name
+    List.model_name
+  end
+end

--- a/app/models/basic.rb
+++ b/app/models/basic.rb
@@ -1,5 +1,4 @@
 class Basic < List
-  validates :title, presence: true
   # enables use of existing route and form helpers
   def self.model_name
     List.model_name

--- a/app/models/grocery.rb
+++ b/app/models/grocery.rb
@@ -1,0 +1,6 @@
+class Grocery < List
+  # enables use of existing route and form helpers
+  def self.model_name
+    List.model_name
+  end
+end

--- a/app/models/instructional.rb
+++ b/app/models/instructional.rb
@@ -1,0 +1,6 @@
+class Instructional < List
+  # enables use of existing route and form helpers
+  def self.model_name
+    List.model_name
+  end
+end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,3 +1,9 @@
 class List < ApplicationRecord
   has_many :list_items, dependent: :destroy
+
+  validates :title, presence: true
+
+  def self.select_options
+    descendants.map{ |c| c.to_s }.sort
+  end
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,3 +1,5 @@
 class ListItem < ApplicationRecord
   belongs_to :list
+
+  validates :description, presence: true
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,0 +1,6 @@
+class Todo < List
+  # enables use of existing route and form helpers
+  def self.model_name
+    List.model_name
+  end
+end

--- a/app/views/layouts/_navbar.slim
+++ b/app/views/layouts/_navbar.slim
@@ -1,5 +1,7 @@
 .container
   .row
-    .column
-      = link_to 'All Lists', lists_path, class: 'button-clear'
-
+    .column.column-20
+      = link_to 'All Lists', lists_path, class: 'button button-clear'
+    - list_types.each do |type|
+      .column.column-20
+        = link_to type.to_s, lists_path(type: type), class: 'button button-clear'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all' %>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
     <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
     <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
   </head>
 

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <%= form.label :type %>
-  <%= form.collection_select :type, List.select_options, :to_str, :to_str %>
+  <%= form.collection_select :type, list_types, :to_str, :to_str %>
 
   <%= form.label :title %>
   <%= form.text_field :title %>

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -11,8 +11,14 @@
     </div>
   <% end %>
 
+  <%= form.label :type %>
+  <%= form.collection_select :type, List.select_options, :to_str, :to_str %>
+
   <%= form.label :title %>
   <%= form.text_field :title %>
+
+  <%= form.label :description %>
+  <%= form.text_field :description %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,11 +1,13 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Lists</h1>
+<h1><%= list_display_heading %></h1>
 
 <table>
   <thead>
     <tr>
-      <th colspan="4"></th>
+      <th>Title</th>
+      <th>Type</th>
+      <th colspan="3"></th>
     </tr>
   </thead>
 
@@ -13,6 +15,7 @@
     <% @lists.each do |list| %>
       <tr>
         <td><%= list.title %></td>
+        <td><%= list.type %></td>
         <td><%= link_to 'Show', list %></td>
         <td><%= link_to 'Edit', edit_list_path(list) %></td>
         <td><%= link_to 'Destroy', list, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,6 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <h1><%= @list.title %></h1>
+<p>Type: <%= @list.type %></p>
+<p>Description: <%= @list.description %></p>
 
 <table class="list-items">
   <thead>

--- a/config/initializers/preload_sti_models.rb
+++ b/config/initializers/preload_sti_models.rb
@@ -1,0 +1,7 @@
+# Rails lazy loads models in development
+# this loads our STI models so dev functions like prod & test environs
+if Rails.env.development?
+  %w[list basic grocery instructional todo].each do |c|
+    require_dependency File.join("app","models","#{c}.rb")
+  end
+end

--- a/db/migrate/20181210225157_add_type_to_lists.rb
+++ b/db/migrate/20181210225157_add_type_to_lists.rb
@@ -1,0 +1,6 @@
+class AddTypeToLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :lists, :type, :string, default: 'Basic'
+    add_index :lists, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_233527) do
+ActiveRecord::Schema.define(version: 2018_12_10_225157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,8 @@ ActiveRecord::Schema.define(version: 2018_12_05_233527) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "type", default: "Basic"
+    t.index ["type"], name: "index_lists_on_type"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/features/user_visits_homepage_test.rb
+++ b/test/features/user_visits_homepage_test.rb
@@ -2,9 +2,15 @@ require 'test_helper'
 
 # smoke test
 feature 'User visits homepage' do
+  let(:list_types) { %w[Basic Grocery Instructional Todo] }
+
   scenario 'successfully' do
     visit root_path
 
-    page.must_have_css 'h1', text: 'Listr'
+    expect(page).must_have_css 'h1', text: 'Listr'
+    expect(page).must_have_css 'a', text: 'All Lists'
+    list_types.each do |type|
+      expect(page).must_have_css 'a', text: type
+    end
   end
 end

--- a/test/models/basic_test.rb
+++ b/test/models/basic_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Basic do
+  it '#model_name' do
+    expect(Basic.model_name.to_str).must_equal 'List'
+  end
+
+  it 'creates a list with the proper type' do
+    list = Basic.new(title: 'MyTitle')
+    expect(list.type).must_equal 'Basic'
+  end
+end

--- a/test/models/grocery_test.rb
+++ b/test/models/grocery_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Grocery do
+  it '#model_name' do
+    expect(Grocery.model_name.to_str).must_equal 'List'
+  end
+
+  it 'creates a list with the proper type' do
+    list = Grocery.new(title: 'MyTitle')
+    expect(list.type).must_equal 'Grocery'
+  end
+end

--- a/test/models/instructional_test.rb
+++ b/test/models/instructional_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Instructional do
+  it '#model_name' do
+    expect(Instructional.model_name.to_str).must_equal 'List'
+  end
+
+  it 'creates a list with the proper type' do
+    list = Instructional.new(title: 'MyTitle')
+    expect(list.type).must_equal 'Instructional'
+  end
+end

--- a/test/models/list_item_test.rb
+++ b/test/models/list_item_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+describe ListItem do
+  let(:valid_list) { List.create(title: 'ValidList') }
+
+  it 'creates a valid ListItem' do
+    item = ListItem.new(description: 'ValidTodo', list_id: valid_list.id)
+    expect(item).must_be :valid?
+  end
+
+  it 'is invalid without a description' do
+    item = ListItem.new(list_id: valid_list.id)
+    expect(item).wont_be :valid?
+  end
+
+  it 'is invalid without a list_id' do
+    item = ListItem.new(description: 'ValidTodo')
+    expect(item).wont_be :valid?
+  end
+end

--- a/test/models/list_test.rb
+++ b/test/models/list_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe List do
+  let(:categories) { %w[Basic Grocery Instructional Todo]}
+
+  it '#select_options' do
+    expect(List.select_options).must_equal categories
+  end
+
+  it 'creates a valid list' do
+    list = List.new(title: 'MyList', type: 'Todo')
+    expect(list).must_be :valid?
+  end
+
+  it 'is invalid without a title' do
+    list = List.new
+    expect(list).wont_be :valid?
+  end
+
+  it 'creates a Basic List when not passed a :type' do
+    list = List.new(title: 'MyList')
+    expect(list).must_be_instance_of Basic
+  end
+end

--- a/test/models/todo_test.rb
+++ b/test/models/todo_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Todo do
+  it '#model_name' do
+    expect(Todo.model_name.to_str).must_equal 'List'
+  end
+
+  it 'creates a list with the proper type' do
+    list = Todo.new(title: 'MyTitle')
+    expect(list.type).must_equal 'Todo'
+  end
+end


### PR DESCRIPTION
This adds 4 sub-classes ('Basic', 'Grocery', 'Instructional', & 'Todo') to create list categories via Single Table Inheritance. I also added nav links to filter the List#index view by type. The default 'Basic' type is for lists that don't fit into any of the categories requested in the original issue.

Given the option, I might have chosen to instead implement the list categorization feature as a 'tag' system with a Category model and a many-to-many relationship with the List model. That would have allowed users to create their own categories and filters. Of course, STI does give us the option of adding extra features and behaviors for each list type which wouldn't have been possible with a Category 'tagging' strategy. Also, it's still possible to implement a tagging feature later if the users do end up wanting that extra flexibility.